### PR TITLE
【UI】サインアップページの切り分け

### DIFF
--- a/client/src/pages/signup/detail/index.tsx
+++ b/client/src/pages/signup/detail/index.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+
+export default function signupPage() {
+  const [signupData, setSignupData] = useState({
+    name: "",
+    phone_number: "",
+    postal_code: "",
+    prefecture: "",
+    city: "",
+    address: "",
+    room_number: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSignupData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+      }}
+    >
+      <Box
+        sx={{
+          height: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box sx={{ marginTop: "20px", marginBottom: "10px" }}>
+          <Image src="/images/logo.png" alt="logo" width={100} height={100} />
+        </Box>
+        <Typography variant="h5" sx={{ marginBottom: "20px" }}>
+          ユーザー詳細情報
+        </Typography>
+        <TextField
+          value={signupData.name}
+          onChange={handleChange}
+          required
+          size="small"
+          id="name"
+          name="name"
+          label="氏名"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.phone_number}
+          onChange={handleChange}
+          required
+          size="small"
+          id="phone_number"
+          name="phone_number"
+          label="電話番号"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.postal_code}
+          onChange={handleChange}
+          required
+          size="small"
+          id="postal_code"
+          name="postal_code"
+          label="郵便番号"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.prefecture}
+          onChange={handleChange}
+          required
+          size="small"
+          id="prefecture"
+          name="prefecture"
+          label="都道府県"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.city}
+          onChange={handleChange}
+          required
+          size="small"
+          id="city"
+          name="city"
+          label="市町村"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.address}
+          onChange={handleChange}
+          required
+          size="small"
+          id="address"
+          name="address"
+          label="番地"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.room_number}
+          onChange={handleChange}
+          size="small"
+          id="room_number"
+          name="room_number"
+          label="部屋番号・階"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <Button
+          size="small"
+          variant="outlined"
+          type="submit"
+          style={{
+            borderColor: "black",
+            background: "#014A8F",
+          }}
+          sx={{
+            color: "white",
+            marginTop: { xs: "10px", sm: "0px" },
+            marginX: "10px",
+            width: "160px",
+            fontSize: "20px",
+          }}
+        >
+          <Link href={""}>登録</Link>
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/client/src/pages/signup/index.tsx
+++ b/client/src/pages/signup/index.tsx
@@ -1,11 +1,37 @@
+import { useState } from "react";
+
 import Image from "next/image";
 import Link from "next/link";
 
-import { Box, Button, TextField } from "@mui/material";
+import { Box, Button, TextField, Typography } from "@mui/material";
 
 export default function signupPage() {
+  const [signupData, setSignupData] = useState({
+    name: "",
+    email: "",
+    password: "",
+    phone_number: "",
+    postal_code: "",
+    prefecture: "",
+    city: "",
+    address: "",
+    room_number: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSignupData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+
+  const signup = async (e: React.FormEvent<HTMLFormElement>) => {};
+
+  console.log(signupData);
+
   return (
-    <main>
+    <form onSubmit={signup}>
       <Box
         sx={{
           width: "100%",
@@ -20,13 +46,19 @@ export default function signupPage() {
             justifyContent: "center",
           }}
         >
-          <Box sx={{ marginBottom: "40px" }}>
-            <Image src="/images/logo.png" alt="logo" width={200} height={100} />
+          <Box sx={{ marginTop: "20px", marginBottom: "10px" }}>
+            <Image src="/images/logo.png" alt="logo" width={100} height={100} />
           </Box>
+          <Typography variant="h5" sx={{ marginBottom: "20px" }}>
+            新規登録
+          </Typography>
           <TextField
+            value={signupData.name}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="name"
+            name="name"
             label="氏名"
             variant="outlined"
             sx={{
@@ -35,9 +67,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.email}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="email"
+            name="email"
             label="メールアドレス"
             variant="outlined"
             sx={{
@@ -46,9 +81,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.password}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="password"
+            name="password"
             label="パスワード"
             variant="outlined"
             type="password"
@@ -59,9 +97,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.phone_number}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="phone_number"
+            name="phone_number"
             label="電話番号"
             variant="outlined"
             sx={{
@@ -70,9 +111,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.postal_code}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="postal_code"
+            name="postal_code"
             label="郵便番号"
             variant="outlined"
             sx={{
@@ -81,9 +125,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.prefecture}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="prefecture"
+            name="prefecture"
             label="都道府県"
             variant="outlined"
             sx={{
@@ -92,9 +139,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.city}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="city"
+            name="city"
             label="市町村"
             variant="outlined"
             sx={{
@@ -103,9 +153,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.address}
+            onChange={handleChange}
+            required
             size="small"
-            defaultValue=""
             id="address"
+            name="address"
             label="番地"
             variant="outlined"
             sx={{
@@ -114,10 +167,12 @@ export default function signupPage() {
             }}
           />
           <TextField
+            value={signupData.room_number}
+            onChange={handleChange}
             size="small"
-            defaultValue=""
-            id="number"
-            label="部屋番号"
+            id="room_number"
+            name="room_number"
+            label="部屋番号・階"
             variant="outlined"
             sx={{
               width: { xs: "240px", sm: "360px" },
@@ -127,6 +182,7 @@ export default function signupPage() {
           <Button
             size="small"
             variant="outlined"
+            type="submit"
             style={{
               borderColor: "black",
               background: "#014A8F",
@@ -143,6 +199,6 @@ export default function signupPage() {
           </Button>
         </Box>
       </Box>
-    </main>
+    </form>
   );
 }

--- a/client/src/pages/signup/index.tsx
+++ b/client/src/pages/signup/index.tsx
@@ -1,21 +1,13 @@
 import { useState } from "react";
 
 import Image from "next/image";
-import Link from "next/link";
 
 import { Box, Button, TextField, Typography } from "@mui/material";
 
 export default function signupPage() {
   const [signupData, setSignupData] = useState({
-    name: "",
     email: "",
     password: "",
-    phone_number: "",
-    postal_code: "",
-    prefecture: "",
-    city: "",
-    address: "",
-    room_number: "",
   });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -27,8 +19,6 @@ export default function signupPage() {
   };
 
   const signup = async (e: React.FormEvent<HTMLFormElement>) => {};
-
-  console.log(signupData);
 
   return (
     <form onSubmit={signup}>
@@ -52,20 +42,6 @@ export default function signupPage() {
           <Typography variant="h5" sx={{ marginBottom: "20px" }}>
             新規登録
           </Typography>
-          <TextField
-            value={signupData.name}
-            onChange={handleChange}
-            required
-            size="small"
-            id="name"
-            name="name"
-            label="氏名"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
           <TextField
             value={signupData.email}
             onChange={handleChange}
@@ -96,93 +72,12 @@ export default function signupPage() {
               marginBottom: "20px",
             }}
           />
-          <TextField
-            value={signupData.phone_number}
-            onChange={handleChange}
-            required
-            size="small"
-            id="phone_number"
-            name="phone_number"
-            label="電話番号"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
-          <TextField
-            value={signupData.postal_code}
-            onChange={handleChange}
-            required
-            size="small"
-            id="postal_code"
-            name="postal_code"
-            label="郵便番号"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
-          <TextField
-            value={signupData.prefecture}
-            onChange={handleChange}
-            required
-            size="small"
-            id="prefecture"
-            name="prefecture"
-            label="都道府県"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
-          <TextField
-            value={signupData.city}
-            onChange={handleChange}
-            required
-            size="small"
-            id="city"
-            name="city"
-            label="市町村"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
-          <TextField
-            value={signupData.address}
-            onChange={handleChange}
-            required
-            size="small"
-            id="address"
-            name="address"
-            label="番地"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
-          <TextField
-            value={signupData.room_number}
-            onChange={handleChange}
-            size="small"
-            id="room_number"
-            name="room_number"
-            label="部屋番号・階"
-            variant="outlined"
-            sx={{
-              width: { xs: "240px", sm: "360px" },
-              marginBottom: "20px",
-            }}
-          />
           <Button
             size="small"
             variant="outlined"
             type="submit"
+            LinkComponent={"a"}
+            href="/signup/detail"
             style={{
               borderColor: "black",
               background: "#014A8F",
@@ -195,7 +90,7 @@ export default function signupPage() {
               fontSize: "20px",
             }}
           >
-            <Link href={""}>登録</Link>
+            次へ
           </Button>
         </Box>
       </Box>


### PR DESCRIPTION
### やったこと
- firebaseの認証を行ったあと、APIをたたくようにするためにサインアップのページを切り分けた
- 最初のページでメールアドレスとパスワードを入力し、firebaseでアカウントを作成＋ログイン
- 次のページでユーザー情報を入力しAPIをたたく