### PR TITLE
【UI】サインアップ、サインイン処理を購入者と代理人それぞれのディレクトリにコピー

### DIFF
--- a/client/src/components/DrawerWrapper/index.tsx
+++ b/client/src/components/DrawerWrapper/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, Drawer, Typography } from "@mui/material";
 import Link from "next/link";
-import { useState } from "react";
+
+import { Box, Button, Drawer, Typography } from "@mui/material";
+
 import { DrawerWrapperProps } from "./types";
 
 export const DrawerWrapper = ({ isOpen, onClose }: DrawerWrapperProps) => {
@@ -23,7 +24,7 @@ export const DrawerWrapper = ({ isOpen, onClose }: DrawerWrapperProps) => {
             fontSize: "24px",
           }}
         >
-          登録する
+          <Link href={"/buyer/signup"}>登録する</Link>
         </Button>
         <Button
           size="large"
@@ -40,7 +41,7 @@ export const DrawerWrapper = ({ isOpen, onClose }: DrawerWrapperProps) => {
             fontSize: "24px",
           }}
         >
-          ログイン
+          <Link href={"/buyer/signin"}>ログイン</Link>
         </Button>
 
         <Typography
@@ -48,7 +49,7 @@ export const DrawerWrapper = ({ isOpen, onClose }: DrawerWrapperProps) => {
           noWrap
           sx={{ fontSize: "16px", marginTop: "10px" }}
         >
-          <Link href={""}>代理人として登録する</Link>
+          <Link href={"/agent/signup"}>代理人として登録する</Link>
         </Typography>
       </Box>
     </Drawer>

--- a/client/src/components/Header/index.tsx
+++ b/client/src/components/Header/index.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import {
   Badge,
   Box,
@@ -48,7 +50,7 @@ export const Header = ({ onClickMenu }: HeaderProps) => {
             },
           }}
         >
-          ログイン
+          <Link href={"/buyer/signin"}>ログイン</Link>
         </Button>
         <Button
           size="large"
@@ -63,7 +65,7 @@ export const Header = ({ onClickMenu }: HeaderProps) => {
             },
           }}
         >
-          新規登録
+          <Link href={"/buyer/signup"}>新規登録</Link>
         </Button>
 
         <Box sx={{ display: { xs: "flex", md: "none" } }}></Box>

--- a/client/src/pages/agent/signin/index.tsx
+++ b/client/src/pages/agent/signin/index.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Box, Button, TextField, Typography } from "@mui/material";
 import { useState } from "react";
 import { getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
-import { app } from "../../lib/firebase";
+import { app } from "@/lib/firebase";
 
 export default function signin() {
   const [email, setEmail] = useState("");

--- a/client/src/pages/agent/signup/detail/index.tsx
+++ b/client/src/pages/agent/signup/detail/index.tsx
@@ -158,7 +158,7 @@ export default function signupPage() {
             fontSize: "20px",
           }}
         >
-          <Link href={"/buyer/select"}>登録</Link>
+          <Link href={"/agent/schedule"}>登録</Link>
         </Button>
       </Box>
     </Box>

--- a/client/src/pages/agent/signup/index.tsx
+++ b/client/src/pages/agent/signup/index.tsx
@@ -35,7 +35,7 @@ export default function signupPage() {
         signupData.password
       );
 
-      router.push("/signup/detail");
+      router.push("/agent/signup/detail");
     } catch (error) {
       alert("登録に失敗しました");
     }

--- a/client/src/pages/buyer/signin/index.tsx
+++ b/client/src/pages/buyer/signin/index.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+import { useState } from "react";
+import { getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
+import { app } from "@/lib/firebase";
+
+export default function signin() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const auth = getAuth(app);
+
+  const login = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      const credential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+
+      const token = await credential.user.getIdToken();
+      await signOut(auth);
+    } catch (error) {
+      alert("ログインに失敗しました");
+    }
+  };
+
+  return (
+    <form onSubmit={login}>
+      <Box
+        sx={{
+          width: "100%",
+        }}
+      >
+        <Box
+          sx={{
+            height: "80vh",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <TextField
+            defaultValue=""
+            id="email"
+            label="メールアドレス"
+            variant="outlined"
+            type="email"
+            sx={{ width: { xs: "200px", sm: "360px" }, marginBottom: "20px" }}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <TextField
+            defaultValue=""
+            id="password"
+            label="パスワード"
+            variant="outlined"
+            type="password"
+            sx={{ width: { xs: "200px", sm: "360px" }, marginBottom: "20px" }}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Button
+            size="small"
+            variant="outlined"
+            type="submit"
+            style={{
+              borderColor: "black",
+              background: "#014A8F",
+            }}
+            sx={{
+              color: "white",
+
+              marginTop: { xs: "10px", sm: "0px" },
+              marginX: "10px",
+              width: "160px",
+              fontSize: "20px",
+            }}
+          >
+            ログイン
+          </Button>
+          <Typography
+            variant="h6"
+            noWrap
+            sx={{ fontSize: "16px", marginTop: "10px" }}
+          >
+            <Link href={""}>新規登録</Link>
+          </Typography>
+        </Box>
+      </Box>
+    </form>
+  );
+}

--- a/client/src/pages/buyer/signup/detail/index.tsx
+++ b/client/src/pages/buyer/signup/detail/index.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+
+export default function signupPage() {
+  const [signupData, setSignupData] = useState({
+    name: "",
+    phone_number: "",
+    postal_code: "",
+    prefecture: "",
+    city: "",
+    address: "",
+    room_number: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSignupData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+      }}
+    >
+      <Box
+        sx={{
+          height: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box sx={{ marginTop: "20px", marginBottom: "10px" }}>
+          <Image src="/images/logo.png" alt="logo" width={100} height={100} />
+        </Box>
+        <Typography variant="h5" sx={{ marginBottom: "20px" }}>
+          ユーザー詳細情報
+        </Typography>
+        <TextField
+          value={signupData.name}
+          onChange={handleChange}
+          required
+          size="small"
+          id="name"
+          name="name"
+          label="氏名"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.phone_number}
+          onChange={handleChange}
+          required
+          size="small"
+          id="phone_number"
+          name="phone_number"
+          label="電話番号"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.postal_code}
+          onChange={handleChange}
+          required
+          size="small"
+          id="postal_code"
+          name="postal_code"
+          label="郵便番号"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.prefecture}
+          onChange={handleChange}
+          required
+          size="small"
+          id="prefecture"
+          name="prefecture"
+          label="都道府県"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.city}
+          onChange={handleChange}
+          required
+          size="small"
+          id="city"
+          name="city"
+          label="市町村"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.address}
+          onChange={handleChange}
+          required
+          size="small"
+          id="address"
+          name="address"
+          label="番地"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <TextField
+          value={signupData.room_number}
+          onChange={handleChange}
+          size="small"
+          id="room_number"
+          name="room_number"
+          label="部屋番号・階"
+          variant="outlined"
+          sx={{
+            width: { xs: "240px", sm: "360px" },
+            marginBottom: "20px",
+          }}
+        />
+        <Button
+          size="small"
+          variant="outlined"
+          type="submit"
+          style={{
+            borderColor: "black",
+            background: "#014A8F",
+          }}
+          sx={{
+            color: "white",
+            marginTop: { xs: "10px", sm: "0px" },
+            marginX: "10px",
+            width: "160px",
+            fontSize: "20px",
+          }}
+        >
+          <Link href={"/buyer/select"}>登録</Link>
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/client/src/pages/buyer/signup/index.tsx
+++ b/client/src/pages/buyer/signup/index.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+
+import Image from "next/image";
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+
+import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
+import { app } from "@/lib/firebase";
+import { useRouter } from "next/router";
+
+export default function signupPage() {
+  const [signupData, setSignupData] = useState({
+    email: "",
+    password: "",
+  });
+
+  const router = useRouter();
+
+  const auth = getAuth(app);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSignupData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+
+  const signup = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      await createUserWithEmailAndPassword(
+        auth,
+        signupData.email,
+        signupData.password
+      );
+
+      router.push("/buyer/signup/detail");
+    } catch (error) {
+      alert("登録に失敗しました");
+    }
+  };
+
+  return (
+    <form onSubmit={signup}>
+      <Box
+        sx={{
+          width: "100%",
+        }}
+      >
+        <Box
+          sx={{
+            height: "100vh",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Box sx={{ marginTop: "20px", marginBottom: "10px" }}>
+            <Image src="/images/logo.png" alt="logo" width={100} height={100} />
+          </Box>
+          <Typography variant="h5" sx={{ marginBottom: "20px" }}>
+            新規登録
+          </Typography>
+          <TextField
+            value={signupData.email}
+            onChange={handleChange}
+            required
+            size="small"
+            id="email"
+            name="email"
+            label="メールアドレス"
+            variant="outlined"
+            sx={{
+              width: { xs: "240px", sm: "360px" },
+              marginBottom: "20px",
+            }}
+          />
+          <TextField
+            value={signupData.password}
+            onChange={handleChange}
+            required
+            size="small"
+            id="password"
+            name="password"
+            label="パスワード"
+            variant="outlined"
+            type="password"
+            sx={{
+              width: { xs: "240px", sm: "360px" },
+
+              marginBottom: "20px",
+            }}
+          />
+          <Button
+            size="small"
+            variant="outlined"
+            type="submit"
+            style={{
+              borderColor: "black",
+              background: "#014A8F",
+            }}
+            sx={{
+              color: "white",
+              marginTop: { xs: "10px", sm: "0px" },
+              marginX: "10px",
+              width: "160px",
+              fontSize: "20px",
+            }}
+          >
+            次へ
+          </Button>
+        </Box>
+      </Box>
+    </form>
+  );
+}


### PR DESCRIPTION
### やったこと
- pages直下にあったサインアップ、サインインのディレクトリを削除し、buyer, agent それぞれのディレクトリにコピー
- ヘッダーとサイドバーのページング